### PR TITLE
Add some bits to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ const DO = withTaskManager(MyDO)
 export { DO }
 ```
 
-The scheduling methods on `TaskManager` are listed below. In all instances `context` is any Javascript object/array/primitive, that you want
+The scheduling methods on `TaskManager` are listed below. In all instances `context` is any Javascript object/array/primitive supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), that you want
 to include in your task when processTask is called.
 
-* `scheduleTaskAt(time: PointInTime, context: any)` where `time` is the time in either ms since the epoch or a JS Date object.
-* `scheduleTaskIn(ms: number, context: any)` where `ms` is the amount of ms for now the task should be scheduled.
-* `scheduleEvery(ms: number, context: any)` where `ms` is the interval in milliseconds that the task should be scheduled.
-* `cancelTask(taskId: taskId)` where taskId is the id that is returned by any of the scheduling functions.
+* `scheduleTaskAt(time: PointInTime, context: any): Promise<taskId>` where `time` is the time in either ms since the epoch or a JS Date object.
+* `scheduleTaskIn(ms: number, context: any): Promise<taskId>` where `ms` is the amount of ms for now the task should be scheduled.
+* `scheduleEvery(ms: number, context: any): Promise<taskId>` where `ms` is the interval in milliseconds that the task should be scheduled.
+* `cancelTask(taskId: taskId): Promise<void>` where taskId is the id that is returned by any of the scheduling functions.
 
-In practice the exact timing that your functionw will be called will depend on many factors and may not be as precise, especially for times within 30 seconds from the time of scheduling.
+In practice the exact timing that your function will be called will depend on many factors and may not be as precise, especially for times within 30 seconds from the time of scheduling.
 
 Please note that if your `processTask` throws an exception, it will retry once a minute until it succeeds. If you want to have a finite number of delivery attempts, you can check the `task.attempts` to see how many times this particular task has been attempted to be delivered before.
 
 TaskManager uses the same durable storage that your durable object uses, with the `$$_tasks` prefix. Which means that if you delete those records either directly, or through a `deleteAll`, it will also delete your tasks.
 
-Manually setting your own alarms should work as normal. TaskManager will intercept those calls and schedule them like a task, except the regular `alarm` method will be called instead of the `processTask` method. But it is recommended to only use Tasks.
+Manually setting your own alarms should work as normal. TaskManager will intercept those calls and schedule them like a task, except the regular `alarm` method will be called instead of the `processTask` method. But it is recommended to only use Tasks. Note that calling `setAlarm` will still override a previous alarm scheduled with `setAlarm`.


### PR DESCRIPTION
Hi,

I've been using a pretty inefficient task scheduling system of my own to manage DO alarms until now, so when I saw this one I had to give it a go, thank you for creating it.

I've added the return types of the schedule calls to the readme to indicate that they are async functions, and the types they give, and I've found with my simple testing that `setAlarm`s differ in that there can still only be one of them, hence the last sentence to make it clear.

I'm not sure what would happen if
- there may or may not be some tasks scheduled far in the future
- the next task to fire is an `alarm` one
- before that fires I call `setAlarm` again, that should cancel the previous one
- the DO alarm still fires as that hasn't been cancelled by `setAlarm`

I'll do some more testing around that this weekend, and perhaps create an issue if the proxied alarm stuff can cause any messy behaviour.

Thanks again.