### PR TITLE
Make environment binding name configurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,14 +105,17 @@ function proxyDO(targetDO: TM_DurableObject, context: TaskContext): TM_DurableOb
 
 const TM_PROP = Symbol('hasTM')
 
-export function withTaskManager<T extends TM_Env>(do_class: TM_DO_class<T>): TM_DO_class<T> {
+export function withTaskManager<T extends TM_Env<U>, U extends string = 'TASK_MANAGER'>(
+  do_class: TM_DO_class<T>,
+  binding_name?: U,
+): TM_DO_class<T> {
   if ((do_class as any)[TM_PROP]) {
     return do_class
   } else {
     const proxy = new Proxy(do_class, {
       construct: (target, [state, env, ...rest]) => {
         const context = new TaskContext(state)
-        env.TASK_MANAGER = new TaskManagerImpl(context)
+        env[binding_name] = new TaskManagerImpl(context)
         const proxiedState = proxyState(state, context)
         const obj = new target(proxiedState, env, ...rest)
         const proxiedDO = proxyDO(obj, context)

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,11 +34,11 @@ export interface TaskProcessor {
 
 export type TM_DurableObject = DurableObject & TaskProcessor
 
-export type TM_Env = {
-  TASK_MANAGER: TaskManager
+export type TM_Env<K extends string = 'TASK_MANAGER'> = {
+  [key in K]: TaskManager
 }
 
-export type TM_DO_class<T extends TM_Env> = {
+export type TM_DO_class<T extends TM_Env<never>> = {
   new (state: DurableObjectState, env: T, ...args: any[]): TM_DurableObject
 }
 


### PR DESCRIPTION
Currently, `env.TASK_MANAGER` is a fixed name for the "output" of `withTaskManager()`.

This PR adds an optional second argument (and SHOULD retain compatibility via defaults) which allows the user to override the binding name.

I'll do some further testing and mark it ready for review soon.