### PR TITLE
Fix for #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@cloudflare/workers-types": "^3.11.0",
     "typescript": "^4.7.3"
   },
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Even though the error message described in #3 suggests that the "module" definition may be incorrect, it seems to have no effect on whether vitest is able to load this package or not. Setting "main" will, however, fix this issue.