### PR TITLE
Fix `DurableObjectState` method proxying

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,8 @@ function proxyState(state: DurableObjectState, context: TaskContext): DurableObj
         return proxyStorage(state.storage, context)
       } else {
         //@ts-ignore
-        return state[prop]
+        const value = state[prop];
+        return typeof value === 'function' ? value.bind(state) : value;
       }
     },
   })


### PR DESCRIPTION
Calling `state.blockConcurrencyWhile()` or `state.waitUntil()` would throw before as they were not bound properly.